### PR TITLE
Add active record 3 support

### DIFF
--- a/lib/stream_rails/sync_policies.rb
+++ b/lib/stream_rails/sync_policies.rb
@@ -5,7 +5,7 @@ module StreamRails
     module SyncCreate
 
       def self.included(base)
-        base.after_commit :add_to_feed, on: [:create]
+        base.after_commit :add_to_feed, on: :create
       end
 
       private
@@ -21,7 +21,7 @@ module StreamRails
     module SyncDestroy
 
       def self.included(base)
-        base.after_commit :remove_from_feed, on: [:destroy]
+        base.after_commit :remove_from_feed, on: :destroy
       end
 
       private


### PR DESCRIPTION
Hi there.

I'm working with rails 3.2.x project now.
And I had tried to integrate stream-rails gem, then I found the errors below.

```ruby
[ERROR] vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.19/lib/active_support/callbacks.rb:404: syntax error, unexpected '[', expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END
          if true && (transaction_include_action?(:[:destroy]))
                                                    ^
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.19/lib/active_support/callbacks.rb:408: syntax error, unexpected '[', expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or tSTRING_END
          if true && (transaction_include_action?(:[:create]))
                                                    ^
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.19/lib/active_support/callbacks.rb:416: syntax error, unexpected keyword_end, expecting ')'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.19/lib/active_support/callbacks.rb:417: syntax error, unexpected $end, expecting ')'
```

This is cased by following issue.
https://github.com/rails/rails/issues/988

Could you fix this, or merge my PR?
Thanks