### PR TITLE
Activity owner should default to actor

### DIFF
--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -37,7 +37,7 @@ module StreamRails
     end
 
     def activity_owner_id
-      self.user_id
+      self.activity_actor.id
     end
 
     def activity_actor


### PR DESCRIPTION
Given this model:

```ruby
class Comment < Sequel::Model
  include StreamRails::Activity
  as_activity

  many_to_one :author, class_name: "User"

  def activity_actor
    self.author
  end
end
```

It would raise an exception upon creation, because the `activity_owner_id` references a `.user_id` property which is non-existent on the model. https://github.com/GetStream/stream-rails/blob/master/lib/stream_rails/activity.rb#L40

One solution would be to override `activity_owner_id` on the model itself, but it makes sense to just use the `actor` by default.
