### PR TITLE
Implement activity synchronization control

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can check out our example app built using this library on Github [https://gi
 - [Model configuration](#model-configuration)
   - [Activity fields](#activity-fields)
   - [Activity extra data](#activity-extra-data)
-  - [Activity creation](#activity-extra-data)
+  - [Activity creation](#activity-creation)
 - [Feed manager](#feed-manager)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can check out our example app built using this library on Github [https://gi
 - [Model configuration](#model-configuration)
   - [Activity fields](#activity-fields)
   - [Activity extra data](#activity-extra-data)
+  - [Activity creation](#activity-extra-data)
 - [Feed manager](#feed-manager)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -139,6 +140,40 @@ class Pin < ActiveRecord::Base
   end
 
 end
+```
+
+####Activity creation
+
+If you want to control when to create an activity you can use the
+```#activity_should_sync=``` call in your model.
+
+```ruby
+class Pin < ActiveRecord::Base
+  belongs_to :author
+  belongs_to :item
+
+  include StreamRails::Activity
+  as_activity
+
+  def activity_should_sync
+    false
+  end
+
+  def activity_object
+    self.item
+  end
+
+end
+```
+
+This will not create an activity after creating a `Pin` object.
+
+You can specify when to create an object like this:
+
+```ruby
+p = Pin.new
+p.activity_should_sync = true
+p.save
 ```
 
 ###Feed manager

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ end
 
 ####Activity creation
 
-If you want to control when to create an activity you can use the
-```#activity_should_sync=``` call in your model.
+If you want to control when to create an activity you should implement
+the ```#activity_should_sync?``` method in your model.
 
 ```ruby
 class Pin < ActiveRecord::Base
@@ -155,8 +155,8 @@ class Pin < ActiveRecord::Base
   include StreamRails::Activity
   as_activity
 
-  def activity_should_sync
-    false
+  def activity_should_sync?
+    self.published
   end
 
   def activity_object
@@ -166,15 +166,7 @@ class Pin < ActiveRecord::Base
 end
 ```
 
-This will not create an activity after creating a `Pin` object.
-
-You can specify when to create an object like this:
-
-```ruby
-p = Pin.new
-p.activity_should_sync = true
-p.save
-```
+This will create an activity only when `self.published` is true.
 
 ###Feed manager
 

--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -31,6 +31,7 @@ module StreamRails
   end
 
   module Activity
+    @should_sync = true
 
     def self.included base
       base.extend ClassMethods
@@ -77,6 +78,18 @@ module StreamRails
 
     def activity_time
       self.created_at.iso8601
+    end
+
+    def activity_should_sync
+      @should_sync
+    end
+
+    def activity_should_sync?
+      self.activity_should_sync
+    end
+
+    def activity_should_sync=(value)
+      @should_sync = value
     end
 
     def create_activity

--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -31,7 +31,6 @@ module StreamRails
   end
 
   module Activity
-    @should_sync = true
 
     def self.included base
       base.extend ClassMethods
@@ -80,16 +79,8 @@ module StreamRails
       self.created_at.iso8601
     end
 
-    def activity_should_sync
-      @should_sync
-    end
-
     def activity_should_sync?
-      self.activity_should_sync
-    end
-
-    def activity_should_sync=(value)
-      @should_sync = value
+      true
     end
 
     def create_activity

--- a/lib/stream_rails/feed_manager.rb
+++ b/lib/stream_rails/feed_manager.rb
@@ -48,9 +48,11 @@ module StreamRails
 
     def created_activity(instance)
       if StreamRails::enabled?
-        activity = instance.create_activity
-        feed = self.get_owner_feed(instance)
-        feed.add_activity(activity)
+        if instance.activity_should_sync?
+          activity = instance.create_activity
+          feed = self.get_owner_feed(instance)
+          feed.add_activity(activity)
+        end
       end
     end
 

--- a/spec/activity_spec.rb
+++ b/spec/activity_spec.rb
@@ -20,7 +20,6 @@ describe 'activity class implementations' do
     instance.should respond_to(:activity_notify)
     instance.should respond_to(:activity_extra_data)
     instance.should respond_to(:activity_should_sync?)
-    instance.should respond_to(:activity_should_sync=)
     instance.should respond_to(:create_activity)
   end
 

--- a/spec/activity_spec.rb
+++ b/spec/activity_spec.rb
@@ -19,6 +19,8 @@ describe 'activity class implementations' do
     instance.should respond_to(:activity_object_id)
     instance.should respond_to(:activity_notify)
     instance.should respond_to(:activity_extra_data)
+    instance.should respond_to(:activity_should_sync?)
+    instance.should respond_to(:activity_should_sync=)
     instance.should respond_to(:create_activity)
   end
 
@@ -77,5 +79,4 @@ describe 'activity class implementations' do
       activity[:object].should_not eq nil
     }
   end
-
 end

--- a/spec/feed_manager_spec.rb
+++ b/spec/feed_manager_spec.rb
@@ -1,9 +1,19 @@
 require 'spec_helper'
+require 'spec_database'
 require 'json'
 
 
 describe 'StreamRails::FeedManager' do
+
     subject { feed_manager }
+
+    context "when instance should not sync" do
+      let(:feed_manager) { StreamRails.feed_manager }
+      describe "#created_activity" do
+        let(:instance) { Article.new }
+        specify { expect(instance).to_not receive(:create_activity); feed_manager.created_activity(instance) }
+      end
+    end
 
     context "instance from StreamRails" do
       let(:feed_manager) { StreamRails.feed_manager }

--- a/spec/feed_manager_spec.rb
+++ b/spec/feed_manager_spec.rb
@@ -11,7 +11,15 @@ describe 'StreamRails::FeedManager' do
       let(:feed_manager) { StreamRails.feed_manager }
       describe "#created_activity" do
         let(:instance) { Article.new }
-        specify { expect(instance).to_not receive(:create_activity); feed_manager.created_activity(instance) }
+        it "should not create activity" do
+          instance.class_eval do
+            def activity_should_sync?
+              false
+            end
+          end
+          expect(instance).to_not receive(:create_activity)
+          feed_manager.created_activity(instance)
+        end
       end
     end
 


### PR DESCRIPTION
From the (new) README section:

If you want to control when to create an activity you can use the
```#activity_should_sync=``` call in your model.

```ruby
class Pin < ActiveRecord::Base
  belongs_to :author
  belongs_to :item

  include StreamRails::Activity
  as_activity

  def activity_should_sync
    false
  end

  def activity_object
    self.item
  end
end
```

This will not create an activity after creating a `Pin` object.

You can specify when to create an object like this:

```ruby
p = Pin.new
p.activity_should_sync = true
p.save
```
