### PR TITLE
Add class name to error message when raising NotImplementedError

### DIFF
--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -47,7 +47,7 @@ module StreamRails
     end
 
     def activity_object
-      fail NotImplementedError, 'Activity models must define `#activity_object`'
+      fail NotImplementedError, "Activity models must define `#activity_object` - missing on `#{self.class}`"
     end
 
     def activity_target

--- a/spec/activity_spec.rb
+++ b/spec/activity_spec.rb
@@ -80,4 +80,15 @@ describe 'activity class implementations' do
       activity[:object].should_not eq nil
     end
   end
+
+  context 'PoorlyImplementedActivity' do
+    before(:all) { use_model(PoorlyImplementedActivity) }
+    specify { has_activity_methods }
+    specify do
+      activity = PoorlyImplementedActivity.new
+
+      error_message = "Activity models must define `#activity_object` - missing on `PoorlyImplementedActivity`"
+      expect { activity.activity_object }.to raise_error(NotImplementedError, error_message)
+    end
+  end
 end

--- a/spec/spec_database.rb
+++ b/spec/spec_database.rb
@@ -44,6 +44,11 @@ class Tweet < BaseModel
   as_activity track_deletes: false
 end
 
+class PoorlyImplementedActivity < BaseModel
+  include StreamRails::Activity
+  as_activity track_deletes: false
+end
+
 module CustomPolicy
   def self.included(base)
     base.before_create :custom_save


### PR DESCRIPTION
Quick addition here to help with debugging. When a `NotImplementedError` is raised due to missing an `#activity_object` definition, it's not necessarily clear *which* class has the problem. Fixed by just adding the class name to the error message.