### PR TITLE
Updated for stream-ruby v2.4.x to allow support for sending updates to activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *.gem
 coverage/
-*.sublime-workspace
 /tmp
 Gemfile.lock
 gemfiles/*.lock
 .DS_Store
+
+# IDE's and editors
+.idea
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Stream Rails
 
 This package helps you create activity streams & newsfeeds with Ruby on Rails and [GetStream.io](https://getstream.io).
 
-###Activity Streams & Newsfeeds
+### Activity Streams & Newsfeeds
 
 ![](https://dvqg2dogggmn6.cloudfront.net/images/mood-home.png)
 

--- a/lib/stream_rails/version.rb
+++ b/lib/stream_rails/version.rb
@@ -1,3 +1,3 @@
 module StreamRails
-  VERSION = '2.4.1'
+  VERSION = '2.5'
 end

--- a/stream_rails.gemspec
+++ b/stream_rails.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |gem|
   gem.version = StreamRails::VERSION
   gem.platform = Gem::Platform::RUBY
   gem.summary = 'A gem that provides a client interface for getstream.io'
-  gem.email = 'tbarbugli@gmail.com'
-  gem.homepage = 'http://github.com/tbarbugli/stream-ruby'
+  gem.email = 'tommaso@getstream.io'
+  gem.homepage = 'http://github.com/GetStream/stream-rails'
   gem.authors = ['Tommaso Barbugli']
   gem.has_rdoc = true
   gem.extra_rdoc_files = ['README.md', 'LICENSE']
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack', '>= 3.0.0'
   gem.add_dependency 'railties', '>= 3.0.0'
-  gem.add_dependency 'stream-ruby', '~> 2.3'
+  gem.add_dependency 'stream-ruby', '~> 2.4'
   gem.add_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
## Summary:
Per https://github.com/GetStream/stream-rails/issues/51 this update was checked and tested against github.com/GetSteam/stream-ruby v2.4.x to ensure no breakage.

## Dependencies:
- [x] verify support with stream-ruby 2.4.x

## Risks:
None, but tagging this as stream-rails v2.5.0 to avoid breakage just in case.
