### PR TITLE
Upgrade to stream-ruby gem 2.5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ gemfiles/*.lock
 # IDE's and editors
 .idea
 *.sublime-workspace
+
+test.sh

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -2,7 +2,8 @@
 
 for i in 3.X 4.0 4.2; do
         echo "Testing active_record $i:"
-        rm -f Gemfile.lock;
-        BUNDLE_GEMFILE=gemfiles/Gemfile.rails-$i bundle > /dev/null;
+        rm -f Gemfile.lock
+        rm -f gemfiles/Gemfile.rails-$i.lock
+        BUNDLE_GEMFILE=gemfiles/Gemfile.rails-$i bundle > /dev/null
         BUNDLE_GEMFILE=gemfiles/Gemfile.rails-$i bundle exec rake
 done

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 for i in 3.X 4.0 4.2; do
-        echo "Testing active_record $i:"
-        rm -f Gemfile.lock
-        rm -f gemfiles/Gemfile.rails-$i.lock
-        BUNDLE_GEMFILE=gemfiles/Gemfile.rails-$i bundle > /dev/null
-        BUNDLE_GEMFILE=gemfiles/Gemfile.rails-$i bundle exec rake
+    echo "Testing active_record $i:"
+    rm -f Gemfile.lock
+    rm -f gemfiles/Gemfile.rails-$i.lock
+    BUNDLE_GEMFILE=gemfiles/Gemfile.rails-$i bundle > /dev/null
+    BUNDLE_GEMFILE=gemfiles/Gemfile.rails-$i bundle exec rake
 done

--- a/spec/feed_manager_spec.rb
+++ b/spec/feed_manager_spec.rb
@@ -41,12 +41,21 @@ describe 'StreamRails::FeedManager' do
 
       specify do
         feed_manager.follow_user(1, 2)
-        body = JSON.parse(FakeWeb.last_request.body)
-        body['target'].should eq 'user:2'
+        user2 = feed_manager.get_user_feed(2)
+        u2followers = user2.followers
+        u2followers['results'][0]['feed_id'].should eq 'aggregated:1'
+        u2followers['results'][1]['feed_id'].should eq 'flat:1'
       end
       specify do
+        user2 = feed_manager.get_user_feed(2)
+        followers1 = user2.followers
+        followers1['results'].should_not eq []
+
         feed_manager.unfollow_user(1, 2)
-        FakeWeb.last_request.method.should eq 'DELETE'
+        followers2 = user2.followers
+
+        followers2.should_not eq followers1
+        followers2['results'].should eq []
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,13 +7,6 @@ $LOAD_PATH.unshift File.expand_path('../../lib/', __FILE__)
 require 'simplecov'
 SimpleCov.start
 
-# require 'fakeweb'
-# FakeWeb.register_uri(
-#   :any,
-#   %r{https://us-east-api\.getstream\.io/},
-#   body: '{}'
-# )
-
 require 'active_record'
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
                                         database: ':memory:')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,12 +7,12 @@ $LOAD_PATH.unshift File.expand_path('../../lib/', __FILE__)
 require 'simplecov'
 SimpleCov.start
 
-require 'fakeweb'
-FakeWeb.register_uri(
-  :any,
-  %r{https://us-east-api\.getstream\.io/},
-  body: '{}'
-)
+# require 'fakeweb'
+# FakeWeb.register_uri(
+#   :any,
+#   %r{https://us-east-api\.getstream\.io/},
+#   body: '{}'
+# )
 
 require 'active_record'
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3',
@@ -22,9 +22,9 @@ require 'stream'
 require 'stream_rails'
 
 StreamRails.configure do |config|
-  config.api_key     = 'key'
-  config.api_secret  = 'secret'
+  config.api_key     = ENV['STREAM_API_KEY']
+  config.api_secret  = ENV['STREAM_API_SECRET']
   config.api_site_id = '42'
-  config.location    = 'us-east'
+  config.location    = ENV['STREAM_REGION']
   config.enabled     = true
 end

--- a/stream_rails.gemspec
+++ b/stream_rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'fakeweb'
+  # gem.add_development_dependency 'fakeweb'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec', '~> 2.10'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'

--- a/stream_rails.gemspec
+++ b/stream_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack', '>= 3.0.0'
   gem.add_dependency 'railties', '>= 3.0.0'
-  gem.add_dependency 'stream-ruby', '~> 2.4'
+  gem.add_dependency 'stream-ruby', '~> 2.5'
   gem.add_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rake'

--- a/stream_rails.gemspec
+++ b/stream_rails.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rake'
-  # gem.add_development_dependency 'fakeweb'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec', '~> 2.10'
   gem.add_development_dependency 'simplecov', '~> 0.7.1'


### PR DESCRIPTION
Our Rails gem will now use the newest version of our https://github.com/GetStream/stream-ruby gem (which has also had a new release today to fix a bug with Faraday). This gem has also removed the FakeWeb gem from testing to ensure accurate testing on our QA environment.