### PR TITLE
Support api_hostname configuration option in newest stream-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ Then you can add the StreamRails configuration in ```config/initializers/stream_
 require 'stream_rails'
 
 StreamRails.configure do |config|
-  config.api_key     = "YOUR API KEY"
-  config.api_secret  = "YOUR API SECRET"
-  config.timeout     = 30                # Optional, defaults to 3
-  config.location    = 'us-east'         # Optional, defaults to 'us-east'
+  config.api_key      = "YOUR API KEY"
+  config.api_secret   = "YOUR API SECRET"
+  config.timeout      = 30                  # Optional, defaults to 3
+  config.location     = 'us-east'           # Optional, defaults to 'us-east'
+  config.api_hostname = 'stream-io-api.com' # Optional, defaults to 'stream-io-api.com' 
   # If you use custom feed names, e.g.: timeline_flat, timeline_aggregated,
   # use this, otherwise omit:
   config.news_feeds = { flat: "timeline_flat", aggregated: "timeline_aggregated" }

--- a/lib/stream_rails.rb
+++ b/lib/stream_rails.rb
@@ -19,7 +19,8 @@ module StreamRails
       config.api_secret,
       config.api_site_id,
       location: config.location,
-      default_timeout: config.timeout
+      default_timeout: config.timeout,
+      api_hostname: config.api_hostname
     )
   end
 
@@ -51,11 +52,12 @@ module StreamRails
   # All available options and their defaults are in the example below:
   # @example Initializer for Rails
   #   StreamRails.configure do |config|
-  #     config.api_key     = "key"
-  #     config.api_secret  = "secret"
-  #     config.api_site_id = "42"
-  #     config.location    = "us-east"
-  #     config.enabled     = true
+  #     config.api_key      = "key"
+  #     config.api_secret   = "secret"
+  #     config.api_site_id  = "42"
+  #     config.location     = "us-east"
+  #     config.api_hostname = "stream-io-api.com"
+  #     config.enabled      = true
   #   end
   def self.configure(&_block)
     yield(config) if block_given?

--- a/lib/stream_rails/config.rb
+++ b/lib/stream_rails/config.rb
@@ -4,6 +4,7 @@ module StreamRails
     attr_accessor :api_key
     attr_accessor :api_secret
     attr_accessor :location
+    attr_accessor :api_hostname
     attr_accessor :api_site_id
     attr_accessor :enabled
     attr_accessor :timeout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,10 @@ require 'stream'
 require 'stream_rails'
 
 StreamRails.configure do |config|
-  config.api_key     = ENV['STREAM_API_KEY']
-  config.api_secret  = ENV['STREAM_API_SECRET']
-  config.api_site_id = '42'
-  config.location    = ENV['STREAM_REGION']
-  config.enabled     = true
+  config.api_key      = ENV['STREAM_API_KEY']
+  config.api_secret   = ENV['STREAM_API_SECRET']
+  config.api_site_id  = '42'
+  config.location     = ENV['STREAM_REGION']
+  config.api_hostname = ENV['STREAM_API_HOSTNAME']
+  config.enabled      = true
 end

--- a/stream_rails.gemspec
+++ b/stream_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack', '>= 3.0.0'
   gem.add_dependency 'railties', '>= 3.0.0'
-  gem.add_dependency 'stream-ruby', '~> 2.5.9'
+  gem.add_dependency 'stream-ruby', '~> 2.5'
   gem.add_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rake'

--- a/stream_rails.gemspec
+++ b/stream_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack', '>= 3.0.0'
   gem.add_dependency 'railties', '>= 3.0.0'
-  gem.add_dependency 'stream-ruby', '~> 2.5'
+  gem.add_dependency 'stream-ruby', '~> 2.5.9'
   gem.add_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Integrates [this stream-ruby PR](https://github.com/GetStream/stream-ruby/pull/77)

[Official announcement](https://getstream.io/blog/stop-using-io-domain-names-for-production-traffic/)