### PR TITLE
underscore model names when creating references

### DIFF
--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -5,7 +5,7 @@ module StreamRails
   class << self
     def create_reference(record)
       if record.is_a?(ActiveRecord::Base) || (Object.const_defined?('Sequel') && record.is_a?(Sequel::Model))
-        "#{record.class.model_name}:#{record.id}"
+        "#{record.class.model_name.to_s.underscore}:#{record.id}"
       else
         record.to_s unless record.nil?
       end


### PR DESCRIPTION
Support namespaced models by underscoring the model name when creating a reference. `Namespaced::Model` becomes `namespaced/model` and `classify` will correctly restore the model name during enrichment.

Note, this affects the usage of #69 since include keys should now be the underscored model name