### PR TITLE
Refactor check aggregated activity is enriched? condition

### DIFF
--- a/lib/stream_rails/renderable.rb
+++ b/lib/stream_rails/renderable.rb
@@ -25,7 +25,7 @@ module StreamRails
       end
 
       def render_aggregated(activity, context, params)
-        if !activity['activities'].map { |a| !a.enriched? }.all?
+        if !activity['activities'].map { |a| a.respond_to?('enriched?') && a.enriched? }.all?
           context.render params
         else
           first_activity = activity['activities'][0]


### PR DESCRIPTION
This removes the following error (undefined method 'enriched?' for #<Hash:0x007fcbd9ea2bd8>) when rendering aggregated activities. See issue #72