### PR TITLE
Fix Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,7 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-4.2
     - rvm: 2.5.1
       gemfile: gemfiles/Gemfile.rails-5.0
+    - rvm: 2.5.1
+      gemfile: gemfiles/Gemfile.rails-5.2
 
 

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for i in 3.X 4.0 4.2; do
+for i in 3.X 4.0 4.2 5.0; do
     echo "Testing active_record $i:"
     rm -f Gemfile.lock
     rm -f gemfiles/Gemfile.rails-$i.lock

--- a/gemfiles/Gemfile.rails-5.0
+++ b/gemfiles/Gemfile.rails-5.0
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec path: '..'
 
 gem 'rake', '< 11.0'
-gem 'actionpack', '~> 4.2.0'
-gem 'railties', '~> 4.2.0'
-gem 'activerecord', '~> 4.2.0'
+gem 'actionpack', '~> 5.2.0'
+gem 'railties', '~> 5.2.0'
+gem 'activerecord', '~> 5.2.0'
 gem 'simplecov', :require => false, :group => :test

--- a/gemfiles/Gemfile.rails-5.0
+++ b/gemfiles/Gemfile.rails-5.0
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+gemspec path: '..'
+
+gem 'rake', '< 11.0'
+gem 'actionpack', '~> 4.2.0'
+gem 'railties', '~> 4.2.0'
+gem 'activerecord', '~> 4.2.0'
+gem 'simplecov', :require => false, :group => :test

--- a/gemfiles/Gemfile.rails-5.2
+++ b/gemfiles/Gemfile.rails-5.2
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 gemspec path: '..'
 
 gem 'rake', '< 11.0'
-gem 'actionpack', '~> 5.0.0'
-gem 'railties', '~> 5.0.0'
-gem 'activerecord', '~> 5.0.0'
+gem 'actionpack', '~> 5.2.0'
+gem 'railties', '~> 5.2.0'
+gem 'activerecord', '~> 5.2.0'
 gem 'simplecov', :require => false, :group => :test

--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -94,7 +94,8 @@ module StreamRails
         time: activity_time
       }
       activity[:to] = activity_notify.map(&:id) unless activity_notify.nil?
-      activity.merge(activity_extra_data) if activity_extra_data != nil
+      activity.merge!(activity_extra_data) if activity_extra_data != nil
+      activity
     end
   end
 end

--- a/stream_rails.gemspec
+++ b/stream_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'actionpack', '>= 3.0.0'
   gem.add_dependency 'railties', '>= 3.0.0'
-  gem.add_dependency 'stream-ruby', '~> 2.5'
+  gem.add_dependency 'stream-ruby', '~> 2.6', '>= 2.6.1'
   gem.add_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Rails 5 builds were failing due to multiple reasons:
1. Missing Gemfile for rails 5.x
2. Incorrect `create_activity` return value
3. Incorrect initialization of default client options in `stream-ruby`, which is now fixed (v2.6.1+)

This PR fixes the above issues, and also supports Rails 5.2 in addition to 5.0.