### PR TITLE
Prevent double #activity_notify calls

### DIFF
--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -94,7 +94,7 @@ module StreamRails
         time: activity_time
       }
       activity[:to] = activity_notify.map(&:id) unless activity_notify.nil?
-      activity.merge!(activity_extra_data) if activity_extra_data != nil
+      activity.merge!(activity_extra_data || {})
       activity
     end
   end

--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -93,9 +93,9 @@ module StreamRails
         target: activity_target_id,
         time: activity_time
       }
-      activity[:to] = activity_notify.map(&:id) unless activity_notify.nil?
+      arr = activity_notify
+      activity[:to] = arr.map(&:id) unless arr.nil?
       activity.merge!(activity_extra_data || {})
-      activity
     end
   end
 end


### PR DESCRIPTION
I was writing a model spec to spy on `activity_notify`; It was making sure proper notification is triggered, and it was triggering `activity_notify` twice. This would remove the need for that as `activity_notify` could be performing a hefty operation.

Also, I've tinkered with making `activity[:to]` default to `[]` but two specs failed. Is nil preferred as a default for this?