### PR TITLE
Jmm/make owner feed name based on actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ActiveRecord models are stored in your feeds as activities; Activities are objec
 
 **#activity_actor** the actor performing the activity -- this value also provides the feed name and feed ID to which the activity will be added.
 
-For example, let's say a Pin was a polymorphic class that could belong to either a user (e.g. `User` ID: 1) or a company (e.g. `Company` ID: 1). In that instance, the below code would post the pin either to the `user:1` feed or the `company:1` based on its owner.
+For example, let's say a Pin was a polymorphic class that could belong to either a user (e.g. `User` ID: 1) or a company (e.g. `Company` ID: 1). In that instance, the below code would post the pin either to the `user:1` feed or the `company:1` feed based on its owner.
 
 ```ruby
 class Pin < ActiveRecord::Base

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ ActiveRecord models are stored in your feeds as activities; Activities are objec
 
 **#activity_object** the object of the activity (eg. an AR model instance)
 
-**#activity_actor** the actor performing the activity -- this value also provides the feed name and feed id to which the activity will be added.
+**#activity_actor** the actor performing the activity -- this value also provides the feed name and feed ID to which the activity will be added.
 
 For example, let's say a Pin was a polymorphic class that could belong to either a user (e.g. User ID 1) or a company (e.g. Company ID 1). In that instance, the below code would post the pin either to the `user:1` feed or the `company:1` based on its owner.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ ActiveRecord models are stored in your feeds as activities; Activities are objec
 
 **#activity_object** the object of the activity (eg. an AR model instance)
 
-**#activity_actor** the actor performing the activity -- this value also provides the feed name and feed id to which the activity will be added (defaults to `self.user`)
+**#activity_actor** the actor performing the activity -- this value also provides the feed name and feed id to which the activity will be added.
 
 For example, let's say a Pin was a polymorphic class that could belong to either a user (e.g. User ID 1) or a company (e.g. Company ID 1). In that instance, the below code would post the pin either to the `user:1` feed or the `company:1` based on its owner.
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ ActiveRecord models are stored in your feeds as activities; Activities are objec
 
 **#activity_actor** the actor performing the activity -- this value also provides the feed name and feed id to which the activity will be added (defaults to `self.user`)
 
+For example, let's say a Pin was a polymorphic class that could belong to either a user (e.g. User ID 1) or a company (e.g. Company ID 1). In that instance, the below code would post the pin either to the `user:1` feed or the `company:1` based on its owner.
+
+```ruby
+class Pin < ActiveRecord::Base
+  belongs_to :owner, :polymorphic => true
+  belongs_to :item
+
+  include StreamRails::Activity
+  as_activity
+
+  def activity_actor
+    self.owner
+  end
+
+  def activity_object
+    self.item
+  end
+
+end
+```
+
+The `activity_actor` defaults to `self.user`
+
+
 **#activity_verb** the string representation of the verb (defaults to model class name)
 
 Here's a more complete example of the Pin class:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ Everytime a Pin is created it will be stored in the feed of the user that create
 ActiveRecord models are stored in your feeds as activities; Activities are objects that tell the story of a person performing an action on or with an object, in its simplest form, an activity consists of an actor, a verb, and an object. In order for this to happen your models need to implement this methods:
 
 **#activity_object** the object of the activity (eg. an AR model instance)
-**#activity_actor** the actor performing the activity (defaults to `self.user`)
+
+**#activity_actor** the actor performing the activity -- this value also provides the feed name and feed id to which the activity will be added (defaults to `self.user`)
+
 **#activity_verb** the string representation of the verb (defaults to model class name)
 
 Here's a more complete example of the Pin class:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ ActiveRecord models are stored in your feeds as activities; Activities are objec
 
 **#activity_actor** the actor performing the activity -- this value also provides the feed name and feed ID to which the activity will be added.
 
-For example, let's say a Pin was a polymorphic class that could belong to either a user (e.g. User ID 1) or a company (e.g. Company ID 1). In that instance, the below code would post the pin either to the `user:1` feed or the `company:1` based on its owner.
+For example, let's say a Pin was a polymorphic class that could belong to either a user (e.g. `User` ID: 1) or a company (e.g. `Company` ID: 1). In that instance, the below code would post the pin either to the `user:1` feed or the `company:1` based on its owner.
 
 ```ruby
 class Pin < ActiveRecord::Base

--- a/lib/stream_rails/activity.rb
+++ b/lib/stream_rails/activity.rb
@@ -39,7 +39,7 @@ module StreamRails
     end
 
     def activity_owner_feed
-      'user'
+      activity_actor.class.name.downcase
     end
 
     def activity_actor_id


### PR DESCRIPTION
Currently, the code uses `activity_actor` to determine what the `activity_owner_id` should be, but for `activity_owner_feed`, the value is hard-coded to `"user"`. This leads to the situation where you could potentially post to the `"user"` feed but use a different model's `id`. 

The fix here is to use `activity_actor` for the `activity_owner_feed` as well. Because `activity_actor` defaults to user, it should be completely backwards compatible.