### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} with Rails ${{ matrix.rails }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   reviewdog:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,6 +6,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   reviewdog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **2** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge
